### PR TITLE
Potential fix for code scanning alert no. 3: Clear text storage of sensitive information

### DIFF
--- a/public/scripts/auth.js
+++ b/public/scripts/auth.js
@@ -132,14 +132,14 @@ document.addEventListener('DOMContentLoaded', function () {
       const user = userCredential.user;
       console.log('Login successful:', user.email);
       
-      // Store user info
+      // User info is available via Firebase Auth (firebaseAuth.currentUser).
+      // Avoid storing authentication-related data in localStorage as clear text.
       const userInfo = {
         uid: user.uid,
         email: user.email,
         displayName: user.displayName || email.split('@')[0]
       };
       
-      localStorage.setItem("user", JSON.stringify(userInfo));
       console.log("Redirecting to courses page...");
       window.location.href = 'courses.html';
       


### PR DESCRIPTION
Potential fix for [https://github.com/RadoSavy/Matura-Master/security/code-scanning/3](https://github.com/RadoSavy/Matura-Master/security/code-scanning/3)

In general, to fix clear‑text storage issues you either (a) avoid storing the sensitive information client‑side, or (b) store only an opaque, non‑sensitive value (e.g., a random session ID) that can be used to look up the data on a secure backend. Client‑side encryption is possible but offers limited protection if an attacker can execute arbitrary JavaScript, because they can usually access the key. In a pure front‑end context, the safest and simplest change is to avoid persisting the user information altogether, relying instead on Firebase’s built‑in session management (Firebase Auth already persists the authenticated user and exposes it via `firebaseAuth.currentUser`).

The minimal change that removes the vulnerability without changing observable functionality too much is to stop writing `userInfo` into `localStorage`. Code outside this snippet can still retrieve the current user via `window.firebaseAuth.currentUser` after page load, so the app can function without its own `localStorage` cache. Concretely, in `public/scripts/auth.js` you should remove or neutralize the `localStorage.setItem("user", JSON.stringify(userInfo));` line (e.g., comment it out or replace it with a safer alternative). No additional imports or helper methods are needed for this fix.

Specifically:
- In `public/scripts/auth.js`, locate line 142 where `localStorage.setItem("user", JSON.stringify(userInfo));` is called.
- Remove this write to `localStorage`, or, if some form of persistence is still desired, store only a non‑sensitive flag (e.g., `"true"`) or a minimally identifying value that your threat model considers safe.
- Leave the rest of the login flow (Firebase call, redirect) unchanged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
